### PR TITLE
Skip already downloaded songs

### DIFF
--- a/amusing/core/parse_csv.py
+++ b/amusing/core/parse_csv.py
@@ -141,7 +141,7 @@ def process_csv(filename: str, download_path: str, session: Session):
             session.commit()
 
         # Submit the group processing task to the ThreadPoolExecutor
-        process_groups(album_name, album_dir, group, album, dir_already_present)
+        process_groups(album_name, album_dir, group, session, album, dir_already_present)
 
         # Sleep after every 5th group
         if len(group) >= 5:

--- a/amusing/core/parse_csv.py
+++ b/amusing/core/parse_csv.py
@@ -83,8 +83,7 @@ def process_groups(
                         "preferredcodec": "m4a",
                     }
                 ],
-                "paths": {"home": album_dir},
-                "outtmpl": {"pl_thumbnail": ""},
+                "outtmpl": f"{album_dir}/{song_name}.%(ext)s",
                 "postprocessors": [
                     {"already_have_thumbnail": False, "key": "EmbedThumbnail"}
                 ],


### PR DESCRIPTION
Fix DB errors due to a missing parameter and save songs with their song name.
Some already downloaded songs may be re-downloaded because they are saved with the video title, which could differ from the original song

---
Fixes #3